### PR TITLE
Add cookiecutter to dependencies. Tell setuptools to search src.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 ]
 dependencies = [
    "django>=3.2.14",
+   "cookiecutter>=2.6.0"
 ]
 
 [project.optional-dependencies]
@@ -56,6 +57,7 @@ Tracker = "https://github.com/rsevs3/django-tailwind-4/issues"
 
 [tool.setuptools.packages.find]
 include = ["tailwind*"]
+where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
This PR adds cookiecutter to the dependencies so that the tests in the repository can pass when using `tox`. It also updates the setuptools search location to pick up the `tailwind` package when building a wheel, so that the app can be used when installed.