### PR TITLE
Fix build to include cookiecutter and template files #10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-tailwind-4"
-version = "0.1.2"
+version = "0.1.3"
 description = "Tailwind 4 CSS Framework for Django projects"
 authors = [
    {name = "Ryan Sevelj", email = "rsevs3@gmail.com"},
@@ -63,3 +63,10 @@ zip-safe = false
 
 [tool.setuptools.packages]
 find = {where = ["src"]}
+
+[tool.setuptools.package-data]
+tailwind = [
+    "app_template/**/*",
+    "templates/**/*",
+    "templatetags/**/*",
+]


### PR DESCRIPTION
I had to add some configuration to pyproject.toml to include non python files in the build.

closes #10