### PR TITLE
Fix broken documentation link in tailwind.config.js 

### DIFF
--- a/example/theme/static_src/tailwind.config.js
+++ b/example/theme/static_src/tailwind.config.js
@@ -2,7 +2,7 @@
  * This is a minimal config.
  *
  * If you need the full config, get it from here:
- * https://unpkg.com/browse/tailwindcss@latest/stubs/defaultConfig.stub.js
+ * https://tailwindcss.com/docs/configuration
  */
 
 module.exports = {

--- a/src/tailwind/app_template/{{cookiecutter.app_name}}/static_src/tailwind.config.js
+++ b/src/tailwind/app_template/{{cookiecutter.app_name}}/static_src/tailwind.config.js
@@ -2,7 +2,7 @@
  * This is a minimal config.
  *
  * If you need the full config, get it from here:
- * https://unpkg.com/browse/tailwindcss@latest/stubs/defaultConfig.stub.js
+ * https://tailwindcss.com/docs/configuration
  */
 
 module.exports = {


### PR DESCRIPTION
Replace outdated UNPKG link with official Tailwind CSS documentation URL. The old link (https://unpkg.com/browse/tailwindcss@latest/stubs/defaultConfig.stub.js) was returning "No files found" error.

Fixes #19